### PR TITLE
Import config from pylons and reduce access checks

### DIFF
--- a/ckanext/notify/actions.py
+++ b/ckanext/notify/actions.py
@@ -155,9 +155,6 @@ def slack_channel_show(context, data_dict):
     # Init the data base
     db.init_db(model)
 
-    # Check access
-    toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, data_dict)
-
     # Get the data request
     result = db.Org_Slack_Details.get(id=id)
     if not result:
@@ -325,9 +322,6 @@ def email_channel_show(context, data_dict):
 
     # Init the data base
     db.init_db(model)
-
-    # Check access
-    toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, data_dict)
 
     # Get the data request
     result = db.Org_Email_Details.get(id=id)

--- a/ckanext/notify/auth.py
+++ b/ckanext/notify/auth.py
@@ -4,7 +4,4 @@ import ckan.lib.helpers as helpers
 def manage_notifications(context, data_dict):
     my_organizations = helpers.organizations_available()
     can_manage = [org['name'] for org in my_organizations]
-    if data_dict['organization_id'] in can_manage:
-        return {'success': True}
-    else:
-        return {'success': False, 'msg': 'You do not have permission to register slack for this organization'}
+    return {'success': data_dict['organization_id'] in can_manage}

--- a/ckanext/notify/controllers/ui_controller.py
+++ b/ckanext/notify/controllers/ui_controller.py
@@ -7,7 +7,8 @@ import ckan.plugins as plugins
 import ckan.lib.helpers as helpers
 import ckanext.notify.constants as constants
 
-from ckan.common import config, request
+from ckan.common import request
+from pylons import config
 
 log = logging.getLogger(__name__)
 toolkit = plugins.toolkit
@@ -83,7 +84,6 @@ class DataRequestsNotifyUI(base.BaseController):
         new_form = True
 
         try:
-            toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, {'organization_id': organization_id})
             self.post_slack_form(constants.DATAREQUEST_REGISTER_SLACK, context)
 
             c.group_dict = toolkit.get_action('organization_show')(context, {'id': organization_id})
@@ -106,7 +106,6 @@ class DataRequestsNotifyUI(base.BaseController):
         new_form = False
 
         try:
-            toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, data_dict)
             c.slack_data = toolkit.get_action(constants.SLACK_CHANNEL_SHOW)(context, data_dict)
 
             self.post_slack_form(constants.SLACK_CHANNEL_UPDATE, context, id=id)
@@ -180,7 +179,6 @@ class DataRequestsNotifyUI(base.BaseController):
 
         # Check access
         try:
-            toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, {'organization_id': organization_id})
             self.post_email_form(constants.DATAREQUEST_REGISTER_EMAIL, context)
 
             c.group_dict = toolkit.get_action('organization_show')(context, {'id': organization_id})
@@ -203,7 +201,6 @@ class DataRequestsNotifyUI(base.BaseController):
         new_form = False
 
         try:
-            toolkit.check_access(constants.MANAGE_NOTIFICATIONS, context, data_dict)
             c.email_data = toolkit.get_action(constants.EMAIL_CHANNEL_SHOW)(context, data_dict)
 
             self.post_email_form(constants.EMAIL_CHANNEL_UPDATE, context, id=id)


### PR DESCRIPTION
### What does this PR do?
Creates a branch of `ckanext-notify` that is compatible with ckan2.5.4. This PR was created for the sake of approval of this branch and not to be merged.

### Description of Task to be completed?
This PR imports `config` from pylons instead of `ckan.common`. Also, it doesn't check if user has the permission to manage organization when a user opens the new channel form since that authorization was checked in a previous page and will be check before the creation of the channel after filling the form.

### Related Issue
#5
