### PR TITLE
Slack notifications for datasets that have been matched to datarequests.

### DIFF
--- a/ckanext/notify/controllers/ui_controller.py
+++ b/ckanext/notify/controllers/ui_controller.py
@@ -270,11 +270,11 @@ class DataRequestsNotifyUI(base.BaseController):
                             'datarequest_title': result['title'],
                             'datarequest_description': result['description'],
                         }
-            slack_message = {'text': base.render_jinja2('notify/slack/{}.txt'.format(template), extra_vars)}
+            slack_message = base.render_jinja2('notify/slack/{}.txt'.format(template), extra_vars)
 
             for channel in channels:
                 requests.post(
-                    channel['webhook_url'], data=json.dumps(slack_message),
+                    channel['webhook_url'], data=(slack_message),
                     headers={'Content-type': 'application/json'}
                 )
 

--- a/ckanext/notify/templates/notify/slack/datarequest_close.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close.txt
@@ -1,4 +1,4 @@
-{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nIt appears you neglected your duties, a datarequest has been closed on {{ site_title }}. :sob:\n\n",
+{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nThe datarequest {{ datatrequest_title }} has been closed on {{ site_title }}. :sob:\n\n",
     "username": "datarequests-bot",
     "icon_emoji": ":monkey_face:",
     "attachments": [

--- a/ckanext/notify/templates/notify/slack/datarequest_close.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close.txt
@@ -1,3 +1,24 @@
-DataRequest {{ datarequest_title }} has been closed on {{ site_title }}.
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nIt appears you neglected your duties, a datarequest has been closed on {{ site_title }}. :sob:\n\n",
+    "username": "datarequests-bot",
+    "icon_emoji": ":monkey_face:",
+    "attachments": [
+        {
+            "color": "danger",
+            "title": "Click me to view the closed datarequest",
+            "title_link": "{{ datarequest_url }}",
+            "text": "Datarequest description: {{ datarequest_description }}",
+            "thumb_url": "https://media.giphy.com/media/2rtQMJvhzOnRe/giphy.gif",
+            "fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+        }
+    ]}

--- a/ckanext/notify/templates/notify/slack/datarequest_close_accepted_dataset.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close_accepted_dataset.txt
@@ -1,0 +1,24 @@
+{"text": "*[CLOSED WITH ACCEPTED DATASET] Datarequest matched to dataset '{{ accepted_dataset }}' and closed on the Organization: {{ site_title }}*\n\nThe datarequest {{ datatrequest_title }} has been matched! {{ site_title }}. :muscle:\n\n",
+    "username": "datarequests-bot",
+    "icon_emoji": ":monkey_face:",
+    "attachments": [
+        {
+            "color": "danger",
+            "title": "Click me to view the matched dataset",
+            "title_link": "{{ accepted_dataset_url }}",
+            "text": "Datarequest title: {{ datarequest_title }}",
+            "thumb_url": "https://media.giphy.com/media/3o6Ei2uhPW2eRv4c8M/giphy.gif",
+            "fields": [
+                {
+                    "title": "Datarequest link",
+                    "value": "{{ datarequest_url }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+        }
+    ]}

--- a/ckanext/notify/templates/notify/slack/datarequest_comment.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_comment.txt
@@ -1,5 +1,24 @@
-A comment has been made on a DataRequest to your organization on {{ site_title }}.
-
-Title: {{ datarequest_title }}
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[COMMENT] A new comment has been made on a datarequest made to the Organization: {{ site_title }}*\n\nYou should probably head over there and check it out! :running:\n\n",
+    "username": "datarequests-bot",
+    "icon_emoji": ":monkey_face:",
+    "attachments": [
+        {
+            "color": "warning",
+            "title": "Click me to view the comment",
+            "title_link": "{{ datarequest_url }}",
+            "text": "Datarequest description: {{ datarequest_description }}",
+            "thumb_url": "https://media.giphy.com/media/26xBNjd32hiIE4UpO/giphy.gif",
+            "fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+        }
+    ]}

--- a/ckanext/notify/templates/notify/slack/datarequest_create.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_create.txt
@@ -1,7 +1,24 @@
-A new DataRequest has been created on {{ site_title }}:
-
-Title: {{ datarequest_title }}
-
-Description: {{ datarequest_description }}
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[NEW DATAREQUEST] Created on the Organization: {{ site_title }}*\n\nIt appears you have work to do, a new datarequest has been created on {{ site_title }}. :ghost:\n\n",
+	"username": "datarequests-bot",
+	"icon_emoji": ":monkey_face:",
+	"attachments": [
+		{
+			 "color": "#36a64f",
+			"title": "Click me to view the new datarequest",
+            "title_link": "{{ datarequest_url }}",
+			"text": "Datarequest description: {{ datarequest_description }}",
+			"thumb_url": "https://media.giphy.com/media/3o6Ei2uhPW2eRv4c8M/giphy.gif",
+			"fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+		}
+	]}


### PR DESCRIPTION
#### What does this PR do?

Sends a slack notification when a datarequest is closed with an accepted dataset.

#### Description of Task to be completed?

Members of an organization should receive slack notifications for datasets that have been matched to datarequests.

These slack notifications should bring out all the bells and whistles. Maybe include a random giphy of "victory".

#### How should this be manually tested?

Set up slack channel notifications on your organization.
Create a new datarequest and check for a notification in the slack notification channel(s) you've set up.
Close a datarequest and select an accepted dataset in the 'Accepted Dataset' dropdown.
Check for a notification in the slack notification channel(s) you've set up

#### What are the relevant issues?
[#15](https://github.com/CodeForAfricaLabs/ckanext-notify/issues/15)

#### Screenshots:
<img width="986" alt="screen shot 2017-11-27 at 12 23 10 pm" src="https://user-images.githubusercontent.com/25130454/33259400-d75d0762-d36d-11e7-8d2e-a96fbd743b46.png">
